### PR TITLE
TCCR0B not initialized in DigisparkRGB example

### DIFF
--- a/digistump-avr/libraries/DigisparkRGB/DigisparkRGB.cpp
+++ b/digistump-avr/libraries/DigisparkRGB/DigisparkRGB.cpp
@@ -49,6 +49,9 @@ void DigisparkRGBBegin() {
 #ifdef TIMSK0
   TIMSK0 = (1 << TOV0);           // enable overflow interrupt
 #endif
+#ifdef TCCR0B
+  TCCR0B = (1 << CS00);         // start timer, no prescale
+#endif
 
 
   sei(); 


### PR DESCRIPTION
With out this my RGB shields when compiled from 1.6.+ pulse rather than gradually fade.