### PR TITLE
Add dummy .h files to Digispark_Examples and DigiXBetaBonus folders

### DIFF
--- a/digistump-avr/libraries/Digispark_Examples/Digispark_Examples.h
+++ b/digistump-avr/libraries/Digispark_Examples/Digispark_Examples.h
@@ -1,0 +1,1 @@
+//This file allows the Digispark_Examples to appear in the File > Examples menu and fixes the Invalid library warning in Arduino IDE 1.6.6+

--- a/digistump-sam/libraries/DigiXBetaBonus/DigiXBetaBonus.h
+++ b/digistump-sam/libraries/DigiXBetaBonus/DigiXBetaBonus.h
@@ -1,0 +1,1 @@
+//This file allows the DigiXBetaBonus sketches to appear in the File > Examples menu and fixes the Invalid library warning in Arduino IDE 1.6.6+


### PR DESCRIPTION
In Arduino IDE 1.6.6 and 1.6.7 these are considered invalid libraries
without a header file and this causes an `Invalid library...` warning whenever a Digispark
board is selected from the Tools > Board menu or Boards Manager or
Library Manager is opened with a Digispark board selected and the
sketches don't appear in the File > Example menu.

Closes https://github.com/digistump/DigistumpArduino/issues/22