### PR TITLE
Fix sending buffered data

### DIFF
--- a/digistump-avr/libraries/DigisparkCDC/DigiCDC.cpp
+++ b/digistump-avr/libraries/DigisparkCDC/DigiCDC.cpp
@@ -151,7 +151,7 @@ void DigiCDCDevice::usbBegin()
 void DigiCDCDevice::usbPollWrapper()
 {
     usbPoll();
-    while((!(RingBuffer_IsEmpty(&txBuf)))&&(index<9))
+    while((!(RingBuffer_IsEmpty(&txBuf)))&&(index<8))
     {
         tmp[index++] = RingBuffer_Remove(&txBuf);
     }


### PR DESCRIPTION
This fixes support for queuing data (and not sending it off directly) if e.g. the USB connection is disconnected and then reconnected. Using a `< 9` check here produces a buffer overflow.