### PR TITLE
#define __scancode-ascii-table_h_included__

### DIFF
--- a/digistump-avr/libraries/DigisparkKeyboard/scancode-ascii-table.h
+++ b/digistump-avr/libraries/DigisparkKeyboard/scancode-ascii-table.h
@@ -3,6 +3,9 @@
 // Format: most signifficant bit indicates if scan code should be sent with shift modifier
 // remaining 7 bits are to be used as scan code number.
 
+#ifndef __scancode-ascii-table_h_included__
+#define __scancode-ascii-table_h_included__
+
 const unsigned char ascii_to_scan_code_table[] PROGMEM = {
   // /* ASCII:   0 */ 0,
   // /* ASCII:   1 */ 0,
@@ -132,3 +135,5 @@ const unsigned char ascii_to_scan_code_table[] PROGMEM = {
   /* ASCII: 125 */ 176,
   /* ASCII: 126 */ 181
 };
+
+#endif /* __scancode-ascii-table_h_included__ */


### PR DESCRIPTION
To make it easier to override scancode-ascii-table.h

It's hard to override scancode-ascii-table.h (with azerty codes for example), if the file can be include multiple times. With this, we can easily include a custom scancode-ascii-table, since the second include will be ignored.

#include "custom-scancode-ascii-table.h"
#include "DigiKeyboard.h"