### PR TITLE
Fixing wrong return value for ::write()

### DIFF
--- a/digistump-avr/libraries/DigisparkLCD/LiquidCrystal_I2C.cpp
+++ b/digistump-avr/libraries/DigisparkLCD/LiquidCrystal_I2C.cpp
@@ -224,7 +224,7 @@ inline void LiquidCrystal_I2C::command(uint8_t value) {
 
 inline size_t LiquidCrystal_I2C::write(uint8_t value) {
 	send(value, Rs);
-	return 0;
+	return 1;
 }
 
 


### PR DESCRIPTION
Same as here: https://github.com/marcoschwartz/LiquidCrystal_I2C/pull/5