### PR TITLE
Update digispark.ino

### DIFF
--- a/digistump-avr/libraries/WS2811/examples/digispark/digispark.ino
+++ b/digistump-avr/libraries/WS2811/examples/digispark/digispark.ino
@@ -14,9 +14,9 @@ void loop() {
 }
 
 void setPixel(i,r,g,b){
-	rgb[r].r=r;
-    rgb[g].g=g;
-    rgb[b].b=b;
+    rgb[i].r=r;
+    rgb[i].g=g;
+    rgb[i].b=b;
 }
 
 void updatePixels(){


### PR DESCRIPTION
rgb[] array is not correctly indexed inside setPixel() function