### PR TITLE
Add missing yield() support

### DIFF
--- a/digistump-avr/cores/pro/Arduino.h
+++ b/digistump-avr/cores/pro/Arduino.h
@@ -15,6 +15,8 @@
 extern "C"{
 #endif
 
+void yield(void);
+
 #define ATTINY_CORE 1
 
 #define HIGH 0x1

--- a/digistump-avr/cores/pro/hooks.c
+++ b/digistump-avr/cores/pro/hooks.c
@@ -1,0 +1,31 @@
+/*
+  Copyright (c) 2012 Arduino.  All right reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+/**
+ * Empty yield() hook.
+ *
+ * This function is intended to be used by library writers to build
+ * libraries or sketches that supports cooperative threads.
+ *
+ * Its defined as a weak symbol and it can be redefined to implement a
+ * real cooperative scheduler.
+ */
+static void __empty() {
+	// Empty
+}
+void yield(void) __attribute__ ((weak, alias("__empty")));

--- a/digistump-avr/cores/tiny/WProgram.h
+++ b/digistump-avr/cores/tiny/WProgram.h
@@ -18,6 +18,8 @@
 #include "TinyDebugSerial.h"
 #include "HardwareSerial.h"
 
+void yield(void);
+
 uint16_t makeWord(uint16_t w);
 uint16_t makeWord(byte h, byte l);
 

--- a/digistump-avr/cores/tiny/hooks.c
+++ b/digistump-avr/cores/tiny/hooks.c
@@ -1,0 +1,31 @@
+/*
+  Copyright (c) 2012 Arduino.  All right reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+/**
+ * Empty yield() hook.
+ *
+ * This function is intended to be used by library writers to build
+ * libraries or sketches that supports cooperative threads.
+ *
+ * Its defined as a weak symbol and it can be redefined to implement a
+ * real cooperative scheduler.
+ */
+static void __empty() {
+	// Empty
+}
+void yield(void) __attribute__ ((weak, alias("__empty")));


### PR DESCRIPTION
The yield function was added to the Arduino core to allow for cooperative scheduling, but in the case of the AVR core, is simply defined as a void function to prevent error in code that expects it, such as the FastLED library. 

This patch removes the "error: 'yield' was not declared in this scope" compile failure from the digispark and digispark pro cores.