### PR TITLE
add RTS and DTR to SerialUSB

### DIFF
--- a/digistump-avr/libraries/DigisparkCDC/DigiCDC.cpp
+++ b/digistump-avr/libraries/DigisparkCDC/DigiCDC.cpp
@@ -16,6 +16,13 @@ and Digistump LLC (digistump.com)
 
 uchar              sendEmptyFrame;
 static uchar       intr3Status;    /* used to control interrupt endpoint transmissions */
+static volatile union {
+    uchar u8;
+    struct {
+        bool dtr: 1;
+        bool rts: 1;
+    } name;
+} controlLines;
 
 DigiCDCDevice::DigiCDCDevice(void){}
 
@@ -79,6 +86,17 @@ int DigiCDCDevice::read()
         return RingBuffer_Remove(&rxBuf);
     }
    
+
+}
+
+bool DigiCDCDevice::getDTR()
+{
+    return controlLines.name.dtr;
+}
+
+bool DigiCDCDevice::getRTS()
+{
+    return controlLines.name.rts;
 }
 
 int DigiCDCDevice::peek()
@@ -325,6 +343,7 @@ usbRequest_t    *rq = (usbRequest_t*)((void *)data);
              */
             if( intr3Status==0 )
                 intr3Status = 2;
+            controlLines.u8 = rq->wValue.word;
         }
 
         /*  Prepare bulk-in endpoint to respond to early termination   */

--- a/digistump-avr/libraries/DigisparkCDC/DigiCDC.h
+++ b/digistump-avr/libraries/DigisparkCDC/DigiCDC.h
@@ -45,6 +45,8 @@ class DigiCDCDevice  : public Stream {
         virtual int available(void);
         virtual int peek(void);
         virtual int read(void);
+        virtual bool getDTR(void);
+        virtual bool getRTS(void);
         virtual void flush(void);
         virtual size_t write(uint8_t);
         using Print::write;


### PR DESCRIPTION
I find the control lines to be useful for out-of-band signalling e.g. for resetting a program while sending raw data as bytes over serial.

For example in this USB to OLED sketch.
```c++
#include <DigiCDC.h>
#include <DigisparkOLED.h>

void setup()
{
    SerialUSB.begin();
    oled.begin();
}

void loop()
{
    static bool rts_old = false;
    bool rts = false;

    if (SerialUSB.available()) {
        char c = SerialUSB.read();
        oled.ssd1306_send_data_byte(c);
    }

    rts = SerialUSB.getRTS();
    if (rts_old != rts) {
        rts_old = rts;
        oled.clear();
    }
}
```

Is this a feature you would like to merge?